### PR TITLE
Respect JVM proxy settings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ This plugin allows easy launching of [mabl](https://www.mabl.com) journeys as a 
 
 Now builds from this plan will trigger Mabl test plan executions of the chosen configuration.
 
+### Proxy Settings
+
+This plugin respects outbound proxy settings you have configured for your server as described in [Atlassian's instructions.](https://confluence.atlassian.com/kb/how-to-configure-outbound-http-and-https-proxy-for-your-atlassian-application-834000120.html)
+
 ## Installation
 
 ### From the marketplace

--- a/src/main/java/com/mabl/RestApiClient.java
+++ b/src/main/java/com/mabl/RestApiClient.java
@@ -116,6 +116,7 @@ public class RestApiClient implements AutoCloseable {
 
     private CloseableHttpClient getHttpClient(String restApiKey) {
         return HttpClients.custom()
+                .useSystemProperties() // use JVM proxy settings passed in by Bamboo.
                 .setRedirectStrategy(new DefaultRedirectStrategy())
                 .setServiceUnavailableRetryStrategy(getRetryHandler())
                 .setDefaultCredentialsProvider(getApiCredentialsProvider(restApiKey))


### PR DESCRIPTION
Use JVM level proxy settings when configuring the API client.
