### PR TITLE
Fix: Allow execution on remote agents

### DIFF
--- a/src/main/java/plugin/impl/MyPluginComponentImpl.java
+++ b/src/main/java/plugin/impl/MyPluginComponentImpl.java
@@ -12,22 +12,13 @@ import javax.inject.Named;
 @Named ("myPluginComponent")
 public class MyPluginComponentImpl implements MyPluginComponent
 {
-    @ComponentImport
-    private final ApplicationProperties applicationProperties;
-
     @Inject
-    public MyPluginComponentImpl(final ApplicationProperties applicationProperties)
+    public MyPluginComponentImpl()
     {
-        this.applicationProperties = applicationProperties;
     }
 
     public String getName()
     {
-        if(null != applicationProperties)
-        {
-            return "myComponent:" + applicationProperties.getDisplayName();
-        }
-        
         return "myComponent";
     }
 }


### PR DESCRIPTION
This PR fixes a bug that prevented using the plugin on remote agents.

When running on a remote agent, the Bamboo plugin is running in JVM that is slightly different from the JVM used when run on the Local agent. On the remote agent, some classes are not available. This was causing the plugin to fail to load on a remote agent and resulted in a somewhat cryptic error message: 

```
Could not execute task 'Run Mabl Tests' no Plugin with key 'com.mabl.bamboo.bamboo-plugin:createdeployment' is installed.
```

In testing it seemed there were two classes being injected that caused the problem: VariableDefinitionManager and ApplicationProperties. Neither of these seem to be required so I removed them. I am now using the custom variable context to read the configuration setting.

See this discussion for more background on the JVM class loading issue:
https://community.atlassian.com/t5/Answers-Developer-Questions/Bamboo-plugin-not-found-on-agents/qaq-p/478515

Also updating some wording.
