### PR TITLE
MABL-2468, MABL-2496: Exposing test case IDs and various fixes/enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the Bamboo mabl plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - TBD
+## [0.0.6] - August 25, 2020
 
 ## Added
 * [MABL-2468](https://mabl.atlassian.net/browse/MABL-2468) Added support for capturing test case IDs and for writing out JUnit test report and allow Bamboo to capture the file as a build artifact

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,47 @@
+# Changelog
+
+All notable changes to the Bamboo mabl plugin will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased] - TBD
+
+## Added
+* [MABL-2468](https://mabl.atlassian.net/browse/MABL-2468) Added support for capturing test case IDs and for writing out JUnit test report and allow Bamboo to capture the file as a build artifact
+* Added support for counting and reporting skipped tests
+
+## Fixed
+* Fixed issue with reporting test duration
+
+## Changed    
+* Retried plans that completed successfully used to cause test failure
+* Updated user-agent string to include JVM and Bamboo version
+* Updated test output to include URL to deployment event
+* Updated components (Powermock, Wiremock, JUnit, Apache HTTP Client)
+
+## [0.1.5] - May 4, 2020
+
+### Fixed
+* [MABL-2097](https://mabl.atlassian.net/browse/MABL-2097) Bamboo plugin: bug on Bamboo 6
+
+## [0.1.4] - April 23, 2020
+
+### Fixed
+* [MABL-1800](https://mabl.atlassian.net/browse/MABL-1800) Bamboo: plugin usage on remote agent
+
+## [0.1.3] - March 26, 2020
+
+### Changed
+* Removed snapshot tag (internal release)
+
+## [0.0.10] - April 2, 2019
+
+## Fixed
+* Respect JVM proxy settings
+
+[Unreleased]: https://github.com/mablhq/bamboo-plugin/compare/bamboo-plugin-0.1.5...head
+[0.1.5]: https://github.com/mablhq/bamboo-plugin/compare/bamboo-plugin-0.1.4...bamboo-plugin-0.1.5
+[0.1.4]: https://github.com/mablhq/bamboo-plugin/compare/bamboo-plugin-0.1.3...bamboo-plugin-0.1.4
+[0.1.3]: https://github.com/mablhq/bamboo-plugin/compare/bamboo-plugin-0.0.10...bamboo-plugin-0.1.3
+[0.0.10]: https://github.com/mablhq/bamboo-plugin/compare/bamboo-plugin-0.0.8...bamboo-plugin-0.0.10

--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,47 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <version>4.0.4</version>
+                <configuration>
+                    <classFilesDirectory>target/classes</classFilesDirectory>
+                    <includeFilterFile>spotbugs-filter.xml</includeFilterFile>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.5</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <!-- attached to Maven test phase -->
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                        <configuration>
+                            <includes>com/mabl/**</includes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
                 <groupId>com.atlassian.maven.plugins</groupId>
                 <artifactId>maven-bamboo-plugin</artifactId>
                 <version>${amps.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,6 @@
             <artifactId>gson</artifactId>
             <version>2.2.2-atlassian-1</version>
         </dependency>
-
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock-standalone</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <powermock.version>1.7.4</powermock.version>
+        <powermock.version>2.0.7</powermock.version>
     </properties>
 
     <dependencies>
@@ -106,12 +106,6 @@
         <dependency>
           <groupId>org.powermock</groupId>
           <artifactId>powermock-module-junit4</artifactId>
-          <version>${powermock.version}</version>
-          <scope>test</scope>
-       </dependency>
-       <dependency>
-          <groupId>org.powermock</groupId>
-          <artifactId>powermock-api-mockito</artifactId>
           <version>${powermock.version}</version>
           <scope>test</scope>
        </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <powermock.version>1.7.1</powermock.version>
+        <powermock.version>1.7.4</powermock.version>
     </properties>
 
     <dependencies>
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.10</version>
+            <version>4.13</version>
             <scope>test</scope>
         </dependency>
 
@@ -91,16 +91,17 @@
             <artifactId>gson</artifactId>
             <version>2.2.2-atlassian-1</version>
         </dependency>
+
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock-standalone</artifactId>
-            <version>2.17.0</version>
+            <artifactId>wiremock-jre8-standalone</artifactId>
+            <version>2.27.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.5</version>
+            <version>4.5.12</version>
         </dependency>
         <dependency>
           <groupId>org.powermock</groupId>

--- a/spotbugs-filter.xml
+++ b/spotbugs-filter.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<FindBugsFilter>
+  <Class name="~com\.mabl\.*\.[^.]+"/>
+</FindBugsFilter>

--- a/src/main/java/com/mabl/ConfiguratorServlet.java
+++ b/src/main/java/com/mabl/ConfiguratorServlet.java
@@ -36,6 +36,12 @@ public class ConfiguratorServlet extends HttpServlet {
             case "labels":
                 doGetLabels(apiClient, response);
                 break;
+            default:
+                try {
+                    response.sendError(400, "request not supported");
+                } catch (IOException e) {
+                    log.warn("Failed to send response");
+                }
         }
 
 	}

--- a/src/main/java/com/mabl/ConfiguratorServlet.java
+++ b/src/main/java/com/mabl/ConfiguratorServlet.java
@@ -38,7 +38,7 @@ public class ConfiguratorServlet extends HttpServlet {
                 break;
             default:
                 try {
-                    response.sendError(400, "request not supported");
+                    response.sendError(HttpServletResponse.SC_BAD_REQUEST, "request not supported");
                 } catch (IOException e) {
                     log.warn("Failed to send response");
                 }

--- a/src/main/java/com/mabl/Converter.java
+++ b/src/main/java/com/mabl/Converter.java
@@ -9,7 +9,7 @@ import java.util.function.Function;
 
 public class Converter {
 
-    public static Function<CustomVariableContext, CreateDeploymentProperties> customVariableContextToCreateDeploymentProperties
+    public static final Function<CustomVariableContext, CreateDeploymentProperties> customVariableContextToCreateDeploymentProperties
             = new Function<CustomVariableContext, CreateDeploymentProperties>() {
         @Override
         public CreateDeploymentProperties apply(CustomVariableContext customVariableContext) {

--- a/src/main/java/com/mabl/CreateDeployment.java
+++ b/src/main/java/com/mabl/CreateDeployment.java
@@ -1,5 +1,6 @@
 package com.mabl;
 
+import com.atlassian.bamboo.artifact.Artifact;
 import com.atlassian.bamboo.build.logger.BuildLogger;
 import com.atlassian.bamboo.build.test.TestCollationService;
 import com.atlassian.bamboo.task.TaskContext;
@@ -8,17 +9,38 @@ import com.atlassian.bamboo.task.TaskResultBuilder;
 import com.atlassian.bamboo.task.TaskType;
 import com.atlassian.bamboo.variable.CustomVariableContext;
 import com.atlassian.bamboo.variable.VariableDefinitionContext;
+import com.atlassian.extras.common.log.Logger;
 import com.atlassian.plugin.spring.scanner.annotation.component.Scanned;
 import com.atlassian.plugin.spring.scanner.annotation.imports.ComponentImport;
+import com.google.common.collect.ImmutableList;
 import com.mabl.domain.CreateDeploymentProperties;
 import com.mabl.domain.CreateDeploymentResult;
 import com.mabl.domain.ExecutionResult;
+import com.mabl.test.output.Failure;
+import com.mabl.test.output.TestCase;
+import com.mabl.test.output.TestSuite;
+import com.mabl.test.output.TestSuites;
 import org.jetbrains.annotations.NotNull;
 
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
+import java.io.File;
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.SortedSet;
+import java.util.TimeZone;
+import java.util.TreeSet;
+import java.util.concurrent.TimeUnit;
 
 import static com.mabl.MablConstants.APPLICATION_ID_FIELD;
 import static com.mabl.MablConstants.COMPLETE_STATUSES;
@@ -32,6 +54,8 @@ import static org.apache.commons.lang.StringUtils.isEmpty;
 
 @Scanned
 public class CreateDeployment implements TaskType {
+    private static final Logger.Log log = Logger.getInstance(CreateDeployment.class);
+
     private final TestCollationService testCollationService;
     private final CustomVariableContext customVariableContext;
 
@@ -46,6 +70,7 @@ public class CreateDeployment implements TaskType {
     @NotNull
     @Override
     public TaskResult execute(@NotNull TaskContext taskContext) {
+        final File junitReport = new File(taskContext.getWorkingDirectory(), "report.xml");
         final BuildLogger buildLogger = taskContext.getBuildLogger();
         final TaskResultBuilder taskResultBuilder = TaskResultBuilder.newBuilder(taskContext);
         final MablOutputProvider mablOutputProvider = new MablOutputProvider();
@@ -70,10 +95,12 @@ public class CreateDeployment implements TaskType {
         try (RestApiClient apiClient = new RestApiClient(MABL_REST_API_BASE_URL, formApiKey)) {
 
             CreateDeploymentResult deployment = apiClient.createDeploymentEvent(environmentId, applicationId, planLabels, properties);
-            buildLogger.addBuildLogEntry(createLogLine("Created deployment with id '%s' and triggered '%d' plans.", deployment.id, deployment.triggeredPlanRunSummaries.size()));
-
+            buildLogger.addBuildLogEntry(
+                    createLogLine(
+                            "Created deployment at https://app.mabl.com/workspaces/%s/events/%s and triggered '%d' plans.",
+                            deployment.workspaceId, deployment.id, deployment.triggeredPlanRunSummaries.size()));
             do {
-                Thread.sleep(EXECUTION_STATUS_POLLING_INTERNAL_MILLISECONDS);
+                TimeUnit.MILLISECONDS.sleep(EXECUTION_STATUS_POLLING_INTERNAL_MILLISECONDS);
                 executionResult = apiClient.getExecutionResults(deployment.id);
 
                 if (executionResult == null) {
@@ -101,6 +128,8 @@ public class CreateDeployment implements TaskType {
             buildLogger.addBuildLogEntry(createLogLine("All plans were successful."));
         }
 
+        generateJUnitReport(junitReport, executionResult.executions);
+
         testCollationService.collateTestResults(taskContext, mablOutputProvider);
         return taskResultBuilder.checkTestFailures().build();
     }
@@ -123,7 +152,7 @@ public class CreateDeployment implements TaskType {
             return false;
         }
 
-        return Boolean.valueOf(context.get(MablConstants.MABL_SEND_VARIABLES_FIELD).getValue());
+        return "true".equalsIgnoreCase(context.get(MablConstants.MABL_SEND_VARIABLES_FIELD).getValue());
     }
 
     private boolean finalOutputStatusAllSuccesses(
@@ -131,38 +160,62 @@ public class CreateDeployment implements TaskType {
             final BuildLogger buildLogger,
             final MablOutputProvider outputProvider
     ) {
-        boolean allPlansSuccess = true;
+
         buildLogger.addBuildLogEntry(createLogLine("The final Plan states in Mabl:"));
+        final Set<String> retriedPlanIDs = new HashSet<>();
+        result.executions.stream().
+                filter(summary -> (summary.planExecution != null && summary.planExecution.isRetry)).
+                filter(summary -> (summary.plan != null && summary.plan.id != null)).
+                forEach(summary -> retriedPlanIDs.add(summary.plan.id));
+
         for (ExecutionResult.ExecutionSummary summary : result.executions) {
             final String successState = summary.success ? "SUCCEEDED" : "FAILED";
-            if(summary.success) {
+            if (summary.success || (summary.planExecution != null &&
+                            !summary.planExecution.isRetry &&
+                            summary.plan != null &&
+                            summary.plan.id != null &&
+                            retriedPlanIDs.contains(summary.plan.id))) {
                 buildLogger.addBuildLogEntry(createLogLine(
-                        "Plan '%s' has %s with state '%s'",
+                        "%sPlan '%s' has %s with state '%s'",
+                        (summary.planExecution != null && summary.planExecution.isRetry) ? "RETRY: " : "",
                         safePlanName(summary),
                         successState,
                         summary.status
                 ));
             } else {
-                allPlansSuccess = false;
                 buildLogger.addErrorLogEntry(createLogErrorLine(
-                        "Plan '%s' has %s with state '%s'",
+                        "%sPlan '%s' has %s with state '%s'",
+                        (summary.planExecution != null && summary.planExecution.isRetry) ? "RETRY: " : "",
                         safePlanName(summary),
                         successState,
                         summary.status
                 ));
             }
 
-            for(ExecutionResult.JourneyExecutionResult journeyResult : summary.journeyExecutions) {
-                long duration = summary.stopTime-summary.startTime;
-                if(journeyResult.success) {
-                    outputProvider.addSuccess(safePlanName(summary), safeJourneyName(summary, journeyResult.id), duration);
+            for (ExecutionResult.JourneyExecutionResult journeyResult : summary.journeyExecutions) {
+                final long duration = journeyResult.stopTime - journeyResult.startTime;
+                final String planName = safePlanName(summary);
+                final String testName = safeJourneyName(summary, journeyResult.id);
+                if (journeyResult.success) {
+                    outputProvider.addSuccess(planName, testName, duration);
+                } else if ("skipped".equals(journeyResult.status)) {
+                    outputProvider.addSkipped(planName, testName);
                 } else {
-                    outputProvider.addFailure(safePlanName(summary), safeJourneyName(summary, journeyResult.id), duration);
+                    // suppress logging test run failures that are retries (i.e. only log the failure if the retry
+                    // failed), otherwise Bamboo will consider this as a plan failure.
+                    if (summary.planExecution == null ||
+                            summary.planExecution.isRetry ||
+                            summary.plan == null ||
+                            summary.plan.id == null ||
+                            !retriedPlanIDs.contains(summary.plan.id)
+                    ) {
+                        outputProvider.addFailure(planName, testName, duration);
+                    }
                 }
             }
         }
 
-        return allPlansSuccess;
+        return (result.eventStatus != null && result.eventStatus.succeeded != null && result.eventStatus.succeeded);
     }
 
     private boolean allPlansComplete(final ExecutionResult result) {
@@ -188,25 +241,26 @@ public class CreateDeployment implements TaskType {
             final BuildLogger buildLogger
     ) {
         buildLogger.addBuildLogEntry(createLogLine(
-                "Plan '%s' is in state '%s'",
+                "  %sPlan '%s' is in state '%s'",
+                (planSummary.planExecution != null && planSummary.planExecution.isRetry) ? "RETRY: " : "",
                 safePlanName(planSummary),
                 planSummary.status
         ));
         for (ExecutionResult.JourneyExecutionResult journeyResult : planSummary.journeyExecutions) {
             buildLogger.addBuildLogEntry(createLogLine(
-                    "Test '%s' is in state '%s'",
+                    "    Test '%s' is in state '%s'",
                     safeJourneyName(planSummary, journeyResult.id),
                     journeyResult.status
             ));
         }
     }
 
-    private String safePlanName(final ExecutionResult.ExecutionSummary summary) {
+    private static String safePlanName(final ExecutionResult.ExecutionSummary summary) {
         // Defensive treatment of possibly malformed future payloads
         return summary.plan != null && !isEmpty(summary.plan.name) ? summary.plan.name : "<Unnamed Plan>";
     }
 
-    private String safeJourneyName(
+    private static String safeJourneyName(
             final ExecutionResult.ExecutionSummary summary,
             final String journeyId
     ) {
@@ -227,7 +281,7 @@ public class CreateDeployment implements TaskType {
     }
 
     private String createLogLine(String logline) {
-        return createLogHelper(false, logline, (Object[]) new Object[0]);
+        return createLogHelper(false, logline);
     }
 
     private String createLogLine(String template, Object... args) {
@@ -241,4 +295,106 @@ public class CreateDeployment implements TaskType {
 
         return String.format(MABL_LOG_OUTPUT_PREFIX+template, args);
     }
+
+    private static void generateJUnitReport(final File reportFile, final List<ExecutionResult.ExecutionSummary> summaries) {
+        List<TestSuite> suites = new ArrayList<>();
+        summaries.forEach(summary -> suites.add(createTestSuite(summary)));
+        TestSuites testSuites = new TestSuites(ImmutableList.copyOf(suites));
+        outputTestSuiteXml(reportFile, testSuites);
+    }
+
+    private static void outputTestSuiteXml(final File reportFile, final TestSuites testSuites) {
+        try {
+            JAXBContext context = JAXBContext.newInstance(TestSuites.class);
+            Marshaller marshaller = context.createMarshaller();
+            marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
+            marshaller.marshal(testSuites, reportFile);
+        } catch (JAXBException e) {
+            log.error("There was an error trying to output test results in mabl.", e);
+        }
+    }
+
+    private static TestSuite createTestSuite(final ExecutionResult.ExecutionSummary summary) {
+        final Date startDate = new Date(summary.startTime);
+        final SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+        format.setTimeZone(TimeZone.getTimeZone("UTC"));
+        final String timestamp = format.format(startDate);
+        final String planName = safePlanName(summary);
+        final TestSuite testSuite = new TestSuite(planName, getDuration(summary), timestamp);
+
+        final Map<String, SortedSet<String>> testCaseIDs = new HashMap<>();
+
+        for (ExecutionResult.JourneyExecutionResult journeyResult : summary.journeyExecutions) {
+            final String testName = safeJourneyName(summary, journeyResult.id);
+            TestCase testCase = new TestCase(
+                    planName,
+                    testName,
+                    getDuration(journeyResult),
+                    journeyResult.appHref
+            );
+
+            if (journeyResult.testCases != null && !journeyResult.testCases.isEmpty()) {
+                switch (journeyResult.status) {
+                    case "failed":
+                    case "completed":
+                    case "skipped":
+                        final SortedSet<String> ids =
+                                testCaseIDs.computeIfAbsent(journeyResult.status + "-test-cases", k -> new TreeSet<>());
+                        for (ExecutionResult.TestCaseID id : journeyResult.testCases) {
+                            ids.add(id.caseID);
+                        }
+
+                        // XRay - report extension
+                        // https://docs.getxray.app/display/XRAYCLOUD/Taking+advantage+of+JUnit+XML+reports
+                        testCase.setTestCaseIDs(ids);
+                        break;
+                    default:
+                        // ignore, only the above statuses are captured
+                }
+            }
+
+            testSuite.addToTestCases(testCase).incrementTests();
+
+            if (!journeyResult.success && null != journeyResult.status) {
+                switch (journeyResult.status) {
+                    case "failed":
+                        // fall through
+                    case "terminated":
+                        final Failure failure = new Failure(journeyResult.status, journeyResult.statusCause);
+                        testCase.setFailure(failure);
+                        testSuite.incrementFailures();
+                        break;
+                    case "skipped":
+                        testCase.setSkipped();
+                        testSuite.incrementSkipped();
+                        break;
+                    default:
+                        log.warn(String.format("unexpected status '%s' found for test '%s' in plan '%s'%n",
+                                journeyResult.status,
+                                planName,
+                                testName));
+                }
+
+            }
+
+        }
+
+        if (!testCaseIDs.isEmpty()) {
+            for (Map.Entry<String,SortedSet<String>> e : testCaseIDs.entrySet()) {
+                testSuite.addProperty(e.getKey(), String.join(",", e.getValue()));
+            }
+        }
+        return testSuite;
+    }
+
+    private static long getDuration(ExecutionResult.ExecutionSummary summary) {
+        return summary.stopTime != null ?
+                TimeUnit.SECONDS.convert( (summary.stopTime - summary.startTime), TimeUnit.MILLISECONDS) : 0;
+    }
+
+    private static long getDuration(ExecutionResult.JourneyExecutionResult summary) {
+        return summary.stopTime != null ?
+                TimeUnit.SECONDS.convert( (summary.stopTime - summary.startTime), TimeUnit.MILLISECONDS) : 0;
+    }
+
 }

--- a/src/main/java/com/mabl/CreateDeployment.java
+++ b/src/main/java/com/mabl/CreateDeployment.java
@@ -1,6 +1,5 @@
 package com.mabl;
 
-import com.atlassian.bamboo.artifact.Artifact;
 import com.atlassian.bamboo.build.logger.BuildLogger;
 import com.atlassian.bamboo.build.test.TestCollationService;
 import com.atlassian.bamboo.task.TaskContext;
@@ -26,11 +25,9 @@ import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
 import java.io.File;
-import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;

--- a/src/main/java/com/mabl/MablConstants.java
+++ b/src/main/java/com/mabl/MablConstants.java
@@ -1,10 +1,12 @@
 package com.mabl;
 
 import com.google.common.collect.ImmutableSet;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
 import java.net.URL;
 import java.util.Enumeration;
+import java.util.Optional;
 import java.util.Set;
 import java.util.jar.Manifest;
 
@@ -25,7 +27,14 @@ class MablConstants {
 
     private static final String PLUGIN_VERSION = getPluginVersion();
     private static final String PLUGIN_VERSION_UNKNOWN = "unknown";
-    static final String PLUGIN_USER_AGENT = "mabl-bamboo-plugin/" + PLUGIN_VERSION;
+    static final String PLUGIN_USER_AGENT;
+    static {
+        String bambooVersion = Optional.ofNullable(System.getProperty("atlassian.sdk.version")).
+                orElse(Optional.ofNullable(System.getenv("AMPS_PLUGIN_VERSION")).
+                                orElse("unknown"));
+        PLUGIN_USER_AGENT = String.format("mabl-bamboo-plugin/%s (JVM: %s, Bamboo: %s)",
+                PLUGIN_VERSION, System.getProperty("java.version"), bambooVersion);
+    }
     static final String MABL_REST_API_BASE_URL = "https://api.mabl.com";
     static final int REQUEST_TIMEOUT_MILLISECONDS = 60000;
     static final int CONNECTION_SECONDS_TO_LIVE = 30;

--- a/src/main/java/com/mabl/MablConstants.java
+++ b/src/main/java/com/mabl/MablConstants.java
@@ -44,6 +44,7 @@ class MablConstants {
     static final String PLAN_LABELS_FIELD = "mablPlanLabels";
     static final String PLAN_LABELS_LABEL_PROPERTY = "createdeployment.planlabels.label";
     static final String MABL_LOG_OUTPUT_PREFIX = "[mabl]";
+    static final String MABL_JUNIT_REPORT_XML = "report.xml";
 
 
     private static final String PLUGIN_SYMBOLIC_NAME = "com.mabl.bamboo.plugin";

--- a/src/main/java/com/mabl/MablConstants.java
+++ b/src/main/java/com/mabl/MablConstants.java
@@ -27,14 +27,8 @@ class MablConstants {
 
     private static final String PLUGIN_VERSION = getPluginVersion();
     private static final String PLUGIN_VERSION_UNKNOWN = "unknown";
-    static final String PLUGIN_USER_AGENT;
-    static {
-        String bambooVersion = Optional.ofNullable(System.getProperty("atlassian.sdk.version")).
-                orElse(Optional.ofNullable(System.getenv("AMPS_PLUGIN_VERSION")).
-                                orElse("unknown"));
-        PLUGIN_USER_AGENT = String.format("mabl-bamboo-plugin/%s (JVM: %s, Bamboo: %s)",
-                PLUGIN_VERSION, System.getProperty("java.version"), bambooVersion);
-    }
+    static final String PLUGIN_USER_AGENT = String.format("mabl-bamboo-plugin/%s (JVM: %s, Bamboo: %s)",
+                PLUGIN_VERSION, System.getProperty("java.version"), getBambooVersion());
     static final String MABL_REST_API_BASE_URL = "https://api.mabl.com";
     static final int REQUEST_TIMEOUT_MILLISECONDS = 60000;
     static final int CONNECTION_SECONDS_TO_LIVE = 30;
@@ -72,5 +66,13 @@ class MablConstants {
             }
         } catch (IOException ignored) {}
         return PLUGIN_VERSION_UNKNOWN;
+    }
+
+    private static String getBambooVersion() {
+        return Optional.ofNullable(System.getProperty("atlassian.sdk.version")).
+                orElseGet(() -> {
+                    final String pluginVersion = System.getenv("AMPS_PLUGIN_VERSION");
+                    return StringUtils.isEmpty(pluginVersion) ? "unknown" : pluginVersion;
+                });
     }
 }

--- a/src/main/java/com/mabl/MablOutputProvider.java
+++ b/src/main/java/com/mabl/MablOutputProvider.java
@@ -13,6 +13,7 @@ import java.util.Collection;
 public class MablOutputProvider implements TestReportProvider {
     public Collection<TestResults> successfulTestResults = Lists.newArrayList();
     public Collection<TestResults> failedTestResults = Lists.newArrayList();
+    public Collection<TestResults> skippedTestResults = Lists.newArrayList();
 
     @Override
     @NotNull
@@ -21,6 +22,7 @@ public class MablOutputProvider implements TestReportProvider {
 
         return builder.addSuccessfulTestResults(successfulTestResults)
                 .addFailedTestResults(failedTestResults)
+                .addSkippedTestResults(skippedTestResults)
                 .build();
     }
 
@@ -40,5 +42,14 @@ public class MablOutputProvider implements TestReportProvider {
 
     public boolean addFailure(String className, String methodName, long duration) {
         return addFailure(new TestResults(className, methodName, duration));
+    }
+
+    public boolean addSkipped(TestResults testResults) {
+        testResults.setState(TestState.SKIPPED);
+        return skippedTestResults.add(testResults);
+    }
+
+    public boolean addSkipped(String className, String methodName) {
+        return addSkipped(new TestResults(className, methodName, 0L));
     }
 }

--- a/src/main/java/com/mabl/RestApiClient.java
+++ b/src/main/java/com/mabl/RestApiClient.java
@@ -10,7 +10,7 @@ import com.mabl.domain.CreateDeploymentProperties;
 import com.mabl.domain.CreateDeploymentResult;
 import com.mabl.domain.CreateDeploymentPayload;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -161,7 +161,7 @@ public class RestApiClient implements AutoCloseable {
                     new CreateDeploymentPayload(environmentId, applicationId, planLabels.isEmpty() ? null : planLabels, properties)
             );
 
-            return new ByteArrayEntity(jsonPayload.getBytes("UTF-8"));
+            return new ByteArrayEntity(jsonPayload.getBytes(StandardCharsets.UTF_8));
 
         } catch (IOException e) {
             log.error(String.format("Unable to create payloadEntity. Reason: '%s'", e.getMessage()));
@@ -175,16 +175,7 @@ public class RestApiClient implements AutoCloseable {
     }
 
     private String base64EncodeUtf8(String toBeEncoded) {
-        try {
-            return Base64.getEncoder().encodeToString(toBeEncoded.getBytes("UTF-8"));
-        } catch (UnsupportedEncodingException e) {
-            log.error(String.format(
-                    "Unable to base64 encode using UTF-8 the string '%s'. Reason:'%s'",
-                    toBeEncoded,
-                    e.getMessage()
-            ));
-            throw new RuntimeException(e.getMessage(), e);
-        }
+        return Base64.getEncoder().encodeToString(toBeEncoded.getBytes(StandardCharsets.UTF_8));
     }
 
     private HttpGet buildGetRequest(final String url) {
@@ -209,13 +200,12 @@ public class RestApiClient implements AutoCloseable {
     private <ApiResult> ApiResult parseApiResult(final HttpResponse response, Class<ApiResult> resultClass) {
         final int statusCode = response.getStatusLine().getStatusCode();
 
-        String message = "";
         switch (statusCode) {
             case SC_OK: // fall through case
             case SC_CREATED:
                 return mapObject(response, resultClass);
             default:
-                message = String.format(
+                final String message = String.format(
                         "Unexpected status returned from parse Api result during fetch %d%n",
                         statusCode
                 );

--- a/src/main/java/com/mabl/domain/CreateDeploymentResult.java
+++ b/src/main/java/com/mabl/domain/CreateDeploymentResult.java
@@ -20,12 +20,12 @@ public class CreateDeploymentResult implements ApiResult {
 
     @JsonCreator
     public CreateDeploymentResult(
-            @JsonProperty("id") String id,
-            @JsonProperty("application_id") String applicationId,
-            @JsonProperty("environment_id") String environmentId,
-            @JsonProperty("received_time") long receivedTime,
-            @JsonProperty("triggered_plan_run_summaries")Set<PlanRunSummary> triggeredPlanRunSummaries,
-            @JsonProperty("plan_labels")Set<String> planLabels,
+            @JsonProperty("id") final String id,
+            @JsonProperty("application_id") final String applicationId,
+            @JsonProperty("environment_id") final String environmentId,
+            @JsonProperty("received_time") final long receivedTime,
+            @JsonProperty("triggered_plan_run_summaries") final Set<PlanRunSummary> triggeredPlanRunSummaries,
+            @JsonProperty("plan_labels") final Set<String> planLabels,
             @JsonProperty("workspace_id") final String workspaceId
             ) {
         this.id = id;

--- a/src/main/java/com/mabl/domain/CreateDeploymentResult.java
+++ b/src/main/java/com/mabl/domain/CreateDeploymentResult.java
@@ -16,6 +16,7 @@ public class CreateDeploymentResult implements ApiResult {
     public long receivedTime;
     public Set<PlanRunSummary> triggeredPlanRunSummaries;
     public Set<String> planLabels;
+    public String workspaceId;
 
     @JsonCreator
     public CreateDeploymentResult(
@@ -24,7 +25,8 @@ public class CreateDeploymentResult implements ApiResult {
             @JsonProperty("environment_id") String environmentId,
             @JsonProperty("received_time") long receivedTime,
             @JsonProperty("triggered_plan_run_summaries")Set<PlanRunSummary> triggeredPlanRunSummaries,
-            @JsonProperty("plan_labels")Set<String> planLabels
+            @JsonProperty("plan_labels")Set<String> planLabels,
+            @JsonProperty("workspace_id") final String workspaceId
             ) {
         this.id = id;
         this.applicationId = applicationId;
@@ -32,6 +34,7 @@ public class CreateDeploymentResult implements ApiResult {
         this.receivedTime = receivedTime;
         this.triggeredPlanRunSummaries = triggeredPlanRunSummaries;
         this.planLabels = planLabels;
+        this.workspaceId = workspaceId;
     }
 
 

--- a/src/main/java/com/mabl/domain/ExecutionResult.java
+++ b/src/main/java/com/mabl/domain/ExecutionResult.java
@@ -1,7 +1,9 @@
 package com.mabl.domain;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
 
 import java.util.List;
 
@@ -11,12 +13,15 @@ import java.util.List;
 
 public class ExecutionResult implements ApiResult {
     public List<ExecutionSummary> executions;
+    public EventStatus eventStatus;
 
     @JsonCreator
     public ExecutionResult(
-            @JsonProperty("executions") final List<ExecutionSummary> executions
+            @JsonProperty("executions") final List<ExecutionSummary> executions,
+            @JsonProperty("event_status") final EventStatus eventStatus
     ) {
         this.executions = executions;
+        this.eventStatus = eventStatus;
     }
 
     @SuppressWarnings("WeakerAccess")
@@ -91,6 +96,16 @@ public class ExecutionResult implements ApiResult {
         }
     }
 
+    public static class TestCaseID {
+        public final String caseID;
+
+        @JsonCreator
+        public TestCaseID(@JsonProperty("id") final String caseID) {
+            this.caseID = caseID;
+        }
+
+    }
+
     @SuppressWarnings("WeakerAccess")
     public static class JourneyExecutionResult {
         public final String id;
@@ -100,6 +115,9 @@ public class ExecutionResult implements ApiResult {
         public final String status;
         public final String statusCause;
         public final boolean success;
+        public final Long startTime;
+        public final Long stopTime;
+        public final List<TestCaseID> testCases;
 
         @JsonCreator
         public JourneyExecutionResult(
@@ -109,7 +127,10 @@ public class ExecutionResult implements ApiResult {
                 @JsonProperty("app_href") final String appHref,
                 @JsonProperty("status") final String status,
                 @JsonProperty("statusCause") final String statusCause,
-                @JsonProperty("success") final boolean success
+                @JsonProperty("success") final boolean success,
+                @JsonProperty("start_time") final Long startTime,
+                @JsonProperty("stop_time") final Long stopTime,
+                @JsonProperty("test_cases") final List<TestCaseID> testCases
         ) {
             this.id = id;
             this.executionId = executionId;
@@ -118,18 +139,65 @@ public class ExecutionResult implements ApiResult {
             this.status = status;
             this.statusCause = statusCause;
             this.success = success;
+            this.startTime = startTime;
+            this.stopTime = stopTime;
+            this.testCases = testCases;
         }
     }
 
     @SuppressWarnings("WeakerAccess")
     public static class PlanExecutionResult {
         public final String id;
+        public final boolean isRetry;
 
         @JsonCreator
         public PlanExecutionResult(
-                @JsonProperty("id") final String id
+                @JsonProperty("id") final String id,
+                @JsonProperty("is_retry") final boolean isRetry
         ) {
             this.id = id;
+            this.isRetry = isRetry;
+        }
+    }
+
+    @SuppressWarnings("WeakerAccess")
+    public static final class EventStatus {
+        public Boolean succeeded;
+        public Boolean succeededFirstAttempt;
+        public Boolean succeededWithRetries;
+
+        public EventStatus(
+        ) {
+        }
+
+        @JsonGetter("succeeded")
+        public Boolean getSucceeded() {
+            return succeeded;
+        }
+
+        @JsonGetter("succeeded_first_attempt")
+        public Boolean getSucceededFirstAttempt() {
+            return succeededFirstAttempt;
+        }
+
+        @JsonGetter("succeeded_with_retries")
+        public Boolean getSucceededWithRetry() {
+            return succeededWithRetries;
+        }
+
+        @JsonSetter("succeeded")
+        public void setSucceeded(Boolean succeeded) {
+            this.succeeded = succeeded;
+        }
+
+        @JsonSetter("succeeded_first_attempt")
+        public void setSucceededFirstAttempt(Boolean succeededFirstAttempt) {
+            this.succeededFirstAttempt = succeededFirstAttempt;
+        }
+
+        @JsonSetter("succeeded_with_retries")
+        public void setSucceededWithRetry(Boolean succeededWithRetries) {
+            this.succeededWithRetries = succeededWithRetries;
         }
     }
 }

--- a/src/main/java/com/mabl/domain/ExecutionResult.java
+++ b/src/main/java/com/mabl/domain/ExecutionResult.java
@@ -96,12 +96,12 @@ public class ExecutionResult implements ApiResult {
         }
     }
 
-    public static class TestCaseID {
-        public final String caseID;
+    public static class TestCaseId {
+        public final String caseId;
 
         @JsonCreator
-        public TestCaseID(@JsonProperty("id") final String caseID) {
-            this.caseID = caseID;
+        public TestCaseId(@JsonProperty("id") final String caseId) {
+            this.caseId = caseId;
         }
 
     }
@@ -117,7 +117,7 @@ public class ExecutionResult implements ApiResult {
         public final boolean success;
         public final Long startTime;
         public final Long stopTime;
-        public final List<TestCaseID> testCases;
+        public final List<TestCaseId> testCases;
 
         @JsonCreator
         public JourneyExecutionResult(
@@ -130,7 +130,7 @@ public class ExecutionResult implements ApiResult {
                 @JsonProperty("success") final boolean success,
                 @JsonProperty("start_time") final Long startTime,
                 @JsonProperty("stop_time") final Long stopTime,
-                @JsonProperty("test_cases") final List<TestCaseID> testCases
+                @JsonProperty("test_cases") final List<TestCaseId> testCases
         ) {
             this.id = id;
             this.executionId = executionId;

--- a/src/main/java/com/mabl/test/output/Failure.java
+++ b/src/main/java/com/mabl/test/output/Failure.java
@@ -1,0 +1,35 @@
+package com.mabl.test.output;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlValue;
+
+@XmlRootElement(name = "failure")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class Failure {
+
+    @XmlValue()
+    private String reason;
+
+    @XmlAttribute(name = "message")
+    private String message;
+
+    public Failure() {
+
+    }
+
+    public Failure(String reason, String message) {
+        this.reason = reason;
+        this.message = message;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public String getReason() {
+        return this.reason;
+    }
+}

--- a/src/main/java/com/mabl/test/output/Properties.java
+++ b/src/main/java/com/mabl/test/output/Properties.java
@@ -1,0 +1,38 @@
+package com.mabl.test.output;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+@XmlRootElement(name = "properties")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class Properties {
+
+    @XmlElement(name = "property")
+    private List<Property> properties;
+
+    public Properties(List<Property> properties) {
+        this.properties = properties;
+    }
+
+    public Properties() {
+
+    }
+
+    public Collection<Property> getProperties() {
+        return Collections.unmodifiableCollection(this.properties);
+    }
+
+    public void addProperty(String name, String value) {
+        if (properties == null) {
+            properties = new ArrayList<>();
+        }
+        properties.add(new Property(name, value));
+    }
+
+}

--- a/src/main/java/com/mabl/test/output/Property.java
+++ b/src/main/java/com/mabl/test/output/Property.java
@@ -1,0 +1,33 @@
+package com.mabl.test.output;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement(name = "property")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class Property {
+
+    @XmlAttribute(name = "name")
+    private String name;
+
+    @XmlAttribute(name = "value")
+    private String value;
+
+    public Property(String name, String value) {
+        this.name = name;
+        this.value = value;
+    }
+
+    public Property() {
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public String getValue() {
+        return this.value;
+    }
+}

--- a/src/main/java/com/mabl/test/output/Skipped.java
+++ b/src/main/java/com/mabl/test/output/Skipped.java
@@ -1,0 +1,13 @@
+package com.mabl.test.output;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * Note that this element has no attributes, no content
+ */
+@XmlRootElement(name="skipped")
+public class Skipped {
+
+    public Skipped() {
+    }
+}

--- a/src/main/java/com/mabl/test/output/TestCase.java
+++ b/src/main/java/com/mabl/test/output/TestCase.java
@@ -1,0 +1,100 @@
+package com.mabl.test.output;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+@XmlRootElement(name = "testcase")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class TestCase {
+
+    @XmlAttribute(name = "classname")
+    private String plan;
+    @XmlAttribute(name = "name")
+    private String journey;
+    @XmlAttribute(name = "time")
+    private long duration;
+    @XmlAttribute(name = "xlink:type")
+    private String linkType;
+    @XmlAttribute(name = "xlink:href")
+    private String appHref;
+
+    @XmlElement(name = "failure")
+    private Failure failure;
+
+    @XmlElement(name = "skipped")
+    private Skipped skipped;
+
+    // Note that this is nan-standard element.
+    // XRay supports this extension, see
+    // https://docs.getxray.app/display/XRAYCLOUD/Taking+advantage+of+JUnit+XML+reports
+    @XmlElement(name = "properties")
+    private Properties properties;
+
+    public TestCase() {
+
+    }
+
+    public TestCase(String plan, String journey, long duration, String appHref) {
+        this(plan, journey, duration, appHref, null);
+    }
+
+    public TestCase(String plan, String journey, long duration, String appHref, Failure failure) {
+        this.plan = plan;
+        this.journey = journey;
+        this.duration = duration;
+        this.linkType = "simple";
+        this.appHref = appHref;
+        this.failure = failure;
+    }
+
+    public void setTestCaseIDs(final Collection<String> testCaseIDs) {
+        if (properties == null) {
+            properties = new Properties();
+        }
+        properties.addProperty("requirement", String.join(",", testCaseIDs));
+    }
+
+    public void setFailure(Failure failure) {
+        this.failure = failure;
+    }
+
+    public void setSkipped() {
+        this.skipped = new Skipped();
+    }
+
+    public String getPlan() {
+        return this.plan;
+    }
+
+    public String getJourney() {
+        return this.journey;
+    }
+
+    public long getDuration() {
+        return this.duration;
+    }
+
+    public String getAppHref() {
+        return this.appHref;
+    }
+
+    public String getLinkType() {
+        return this.linkType;
+    }
+
+    public Failure getFailure() {
+        return this.failure;
+    }
+
+    public Properties getProperties() { return this.properties; }
+
+    public Skipped getSkipped() { return this.skipped; }
+}
+
+

--- a/src/main/java/com/mabl/test/output/TestSuite.java
+++ b/src/main/java/com/mabl/test/output/TestSuite.java
@@ -1,0 +1,122 @@
+package com.mabl.test.output;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@XmlRootElement(name="testsuite")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class TestSuite {
+
+    @XmlAttribute(name = "name")
+    private String name;
+
+    @XmlAttribute(name = "tests")
+    private int tests;
+
+    @XmlAttribute(name = "errors")
+    private int errors;
+
+    @XmlAttribute(name = "failures")
+    private int failures;
+
+    @XmlAttribute(name = "skipped")
+    private int skipped;
+
+    @XmlAttribute(name = "time")
+    private long time;
+
+    @XmlAttribute(name = "timestamp")
+    private String timestamp;
+
+    @XmlElement(name = "properties")
+    private Properties properties;
+
+    @XmlElement(name = "testcase")
+    private List<TestCase> testCases;
+
+    public TestSuite(String name, long time, String timestamp, Properties properties) {
+        this.name = name;
+        this.time = time;
+        this.timestamp = timestamp;
+        this.properties = properties;
+        this.testCases = new ArrayList<>();
+    }
+
+    public TestSuite(String name, long time, String timestamp) {
+        this.name = name;
+        this.time = time;
+        this.timestamp = timestamp;
+        this.testCases = new ArrayList<>();
+    }
+
+    public TestSuite() {
+
+    }
+
+    public TestSuite addToTestCases(TestCase testCase) {
+        this.testCases.add(testCase);
+        return this;
+    }
+
+    public void incrementTests() {
+        this.tests++;
+    }
+
+    public void incrementErrors() {
+        this.errors++;
+    }
+
+    public void incrementFailures() {
+        this.failures++;
+    }
+
+    public void incrementSkipped() {
+        this.skipped++;
+    }
+
+    public void addProperty(final String name, final String value) {
+        if (properties == null) {
+            properties = new Properties();
+        }
+        properties.addProperty(name, value);
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public int getTests() {
+        return this.tests;
+    }
+
+    public int getErrors() {
+        return this.errors;
+    }
+
+    public int getFailures() {
+        return this.failures;
+    }
+
+    public int getSkipped() { return this.skipped; }
+
+    public long getTime() {
+        return this.time;
+    }
+
+    public String getTimestamp() {
+        return this.timestamp;
+    }
+
+    public List<TestCase> getTestCases() { return Collections.unmodifiableList(testCases); }
+
+    public Properties getProperties() {
+        return this.properties;
+    }
+
+}

--- a/src/main/java/com/mabl/test/output/TestSuite.java
+++ b/src/main/java/com/mabl/test/output/TestSuite.java
@@ -49,10 +49,7 @@ public class TestSuite {
     }
 
     public TestSuite(String name, long time, String timestamp) {
-        this.name = name;
-        this.time = time;
-        this.timestamp = timestamp;
-        this.testCases = new ArrayList<>();
+        this(name, time, timestamp, null);
     }
 
     public TestSuite() {

--- a/src/main/java/com/mabl/test/output/TestSuites.java
+++ b/src/main/java/com/mabl/test/output/TestSuites.java
@@ -21,7 +21,7 @@ public class TestSuites {
 
     public TestSuites(ImmutableCollection<TestSuite> testSuites) {
         this.testSuites = testSuites;
-        this.xlink = null; //MablStepConstants.TEST_OUTPUT_XML_XLINK;
+        this.xlink = null;
     }
 
     public TestSuites() {

--- a/src/main/java/com/mabl/test/output/TestSuites.java
+++ b/src/main/java/com/mabl/test/output/TestSuites.java
@@ -1,0 +1,38 @@
+package com.mabl.test.output;
+
+import com.google.common.collect.ImmutableCollection;
+//import com.mabl.integration.jenkins.MablStepConstants;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement(name = "testsuites")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class TestSuites {
+
+    @XmlAttribute(name = "xmlns:xlink")
+    private String xlink;
+
+    @XmlElement(name = "testsuite")
+    private ImmutableCollection<TestSuite> testSuites;
+
+    public TestSuites(ImmutableCollection<TestSuite> testSuites) {
+        this.testSuites = testSuites;
+        this.xlink = null; //MablStepConstants.TEST_OUTPUT_XML_XLINK;
+    }
+
+    public TestSuites() {
+
+    }
+
+    public String getXlink() {
+        return xlink;
+    }
+
+    public ImmutableCollection<TestSuite> getTestSuites() {
+        return testSuites;
+    }
+}

--- a/src/main/resources/i18n.properties
+++ b/src/main/resources/i18n.properties
@@ -1,7 +1,7 @@
 mabl.task.help.link = https://help.mabl.com/v1.0/docs/triggering-tests-via-the-api
 mabl.task.help.title = Find out more
 
-createdeployment.restapikey.label = Api Key
+createdeployment.restapikey.label = API Key
 createdeployment.applicationid.label = Application
 createdeployment.environmentid.label = Environment
 createdeployment.planlabels.label = Labels

--- a/src/test/java/com/mabl/RestApiClientTest.java
+++ b/src/test/java/com/mabl/RestApiClientTest.java
@@ -11,6 +11,7 @@ import com.mabl.domain.GetApiKeyResult;
 import com.mabl.domain.GetApplicationsResult;
 import com.mabl.domain.GetEnvironmentsResult;
 import com.mabl.domain.GetLabelsResult;
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -118,33 +119,32 @@ public class RestApiClientTest extends AbstractWiremockTest {
     }
 
     private void assertSuccessfulCreateDeploymentRequest(final String environmentId, final String applicationId, final Set<String> planLabels) {
-        RestApiClient client = new PartialRestApiClient(getBaseUrl(), fakeRestApiKey);
-        CreateDeploymentProperties properties = new CreateDeploymentProperties();
-        properties.setDeploymentOrigin(MablConstants.PLUGIN_USER_AGENT);
-        CreateDeploymentResult result = client.createDeploymentEvent(environmentId, applicationId, planLabels, properties);
+        try (RestApiClient client = new PartialRestApiClient(getBaseUrl(), fakeRestApiKey)) {
+            CreateDeploymentProperties properties = new CreateDeploymentProperties();
+            properties.setDeploymentOrigin(MablConstants.PLUGIN_USER_AGENT);
+            CreateDeploymentResult result = client.createDeploymentEvent(environmentId, applicationId, planLabels, properties);
 
-        assertEquals(MablTestConstants.EXPECTED_DEPLOYMENT_EVENT_ID, result.id);
-        if(environmentId == null) {
-            assertNull(result.environmentId);
-        } else {
-            assertEquals(MablTestConstants.EXPECTED_DEPLOYMENT_EVENT_ENVIRONMENT_ID, result.environmentId);
+            assertEquals(MablTestConstants.EXPECTED_DEPLOYMENT_EVENT_ID, result.id);
+            if (environmentId == null) {
+                assertNull(result.environmentId);
+            } else {
+                assertEquals(MablTestConstants.EXPECTED_DEPLOYMENT_EVENT_ENVIRONMENT_ID, result.environmentId);
+            }
+
+            if (applicationId == null) {
+                assertNull(result.applicationId);
+            } else {
+                assertEquals(MablTestConstants.EXPECTED_DEPLOYMENT_EVENT_APPLICATION_ID, result.applicationId);
+            }
+
+            if (planLabels.isEmpty()) {
+                assertNull(result.planLabels);
+            } else {
+                assertEquals(planLabels, result.planLabels);
+            }
+
+            verifyExpectedUrls();
         }
-
-        if(applicationId == null) {
-            assertNull(result.applicationId);
-        } else {
-            assertEquals(MablTestConstants.EXPECTED_DEPLOYMENT_EVENT_APPLICATION_ID, result.applicationId);
-        }
-
-        if(planLabels.isEmpty()) {
-            assertNull(result.planLabels);
-        } else {
-            assertEquals(planLabels, result.planLabels);
-        }
-
-        verifyExpectedUrls();
-
-        client.close();
     }
 
     @Test

--- a/src/test/java/com/mabl/RestApiClientTest.java
+++ b/src/test/java/com/mabl/RestApiClientTest.java
@@ -11,12 +11,12 @@ import com.mabl.domain.GetApiKeyResult;
 import com.mabl.domain.GetApplicationsResult;
 import com.mabl.domain.GetEnvironmentsResult;
 import com.mabl.domain.GetLabelsResult;
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
@@ -32,6 +32,9 @@ import static com.mabl.RestApiClient.REST_API_USERNAME_PLACEHOLDER;
 import static com.github.tomakehurst.wiremock.client.WireMock.ok;
 import static com.github.tomakehurst.wiremock.client.WireMock.notFound;
 import static org.apache.commons.httpclient.HttpStatus.SC_CREATED;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.isIn;
+import static org.hamcrest.Matchers.everyItem;
 
 public class RestApiClientTest extends AbstractWiremockTest {
     private static final String fakeRestApiKey = "fakeApiKey";
@@ -243,7 +246,8 @@ public class RestApiClientTest extends AbstractWiremockTest {
         assertEquals(5, result.labels.size());
         HashSet<String> expectedLabels =
                 Sets.newHashSet("failsOnRerun", "succeedsOnRerun", "smoke", "local", "regression");
-        result.labels.forEach(label -> assertTrue(expectedLabels.remove(label.name)));
+        Set<String> actualLabels = result.labels.stream().map(label -> label.name).collect(Collectors.toSet());
+        assertThat(actualLabels, everyItem(isIn(expectedLabels)));
     }
 
     @Test(expected = RuntimeException.class)

--- a/src/test/java/com/mabl/TestOutputTests.java
+++ b/src/test/java/com/mabl/TestOutputTests.java
@@ -1,0 +1,116 @@
+package com.mabl;
+
+import com.google.common.collect.ImmutableList;
+import com.mabl.test.output.Failure;
+import com.mabl.test.output.Properties;
+import com.mabl.test.output.Property;
+import com.mabl.test.output.TestCase;
+import com.mabl.test.output.TestSuite;
+import com.mabl.test.output.TestSuites;
+import org.junit.Test;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestOutputTests {
+
+    @Test
+    public void testTestCaseOutputNoFailure() throws JAXBException {
+        TestCase testCase = new TestCase("My Plan Name", "My Test Name", 23L, "http://myapphref.com");
+        JAXBContext jaxbContext = JAXBContext.newInstance(TestCase.class);
+        Marshaller marshaller = jaxbContext.createMarshaller();
+        StringWriter stringWriter = new StringWriter();
+        marshaller.marshal(testCase, stringWriter);
+
+        assertEquals(stringWriter.toString(), readFileAsString("testcase.xml"));
+    }
+
+    @Test
+    public void testTestCaseOutputWithFailure() throws JAXBException {
+        Failure failure = new Failure("My Reason", "My Message");
+        TestCase testCase = new TestCase("My Plan Name", "My Test Name", 23L, "http://myapphref.com", failure);
+        JAXBContext jaxbContext = JAXBContext.newInstance(TestCase.class);
+        Marshaller marshaller = jaxbContext.createMarshaller();
+        StringWriter stringWriter = new StringWriter();
+        marshaller.marshal(testCase, stringWriter);
+        assertEquals(stringWriter.toString(), readFileAsString("testcasewithfailure.xml"));
+    }
+
+    @Test
+    public void testEntireTestSuite() throws JAXBException {
+        TestSuite emptyTestSuite = new TestSuite(
+                "Empty Test Suite",
+                0L,
+                "2013-05-24T10:23:58",
+                new Properties()
+        );
+
+
+        List<Property> props = Arrays.asList(
+                new Property("environment", "my env-e"),
+                new Property("application", "my app-a"),
+                new Property("completed-test-cases", "TESTCASE-1"),
+                new Property("failed-test-cases", "TESTCASE-2"),
+                new Property("skipped-test-cases", "TESTCASE-3")
+        );
+        Properties properties = new Properties(ImmutableList.copyOf(props));
+
+        TestCase testCase1 = new TestCase("My Plan Name 1", "My Test Name 1", 11L, "http://myapphref.com");
+        testCase1.setTestCaseIDs(Collections.singleton("TESTCASE-1"));
+        Failure failure = new Failure("My Reason", "My Message");
+        TestCase testCase2 = new TestCase("My Plan Name 2", "My Test Name 2", 22L, "http://myapphref.com", failure);
+        testCase2.setTestCaseIDs(Collections.singleton("TESTCASE-2"));
+        TestCase testCase3 = new TestCase("My Plan Name 3", "My Test Name 3", 33L, "http://myapphref.com");
+        testCase3.setSkipped();
+        testCase3.setTestCaseIDs(Collections.singleton("TESTCASE-3"));
+
+        TestSuite testSuite1 = new TestSuite(
+                "Full Test Suite",
+                33L,
+                "2013-05-24T10:23:58",
+                properties
+        );
+        testSuite1.addToTestCases(testCase1);
+        testSuite1.incrementTests();
+        testSuite1.addToTestCases(testCase2);
+        testSuite1.incrementTests();
+        testSuite1.incrementFailures();
+        testSuite1.addToTestCases(testCase3);
+        testSuite1.incrementTests();
+        testSuite1.incrementSkipped();
+
+        ArrayList<TestSuite> suites = new ArrayList<>();
+        suites.add(emptyTestSuite);
+        suites.add(testSuite1);
+        TestSuites testSuites = new TestSuites(ImmutableList.copyOf(suites));
+
+        JAXBContext jaxbContext = JAXBContext.newInstance(TestSuites.class);
+        Marshaller marshaller = jaxbContext.createMarshaller();
+        StringWriter stringWriter = new StringWriter();
+        marshaller.marshal(testSuites, stringWriter);
+        assertEquals(stringWriter.toString(), readFileAsString("testsuite.xml"));
+    }
+
+    private static String readFileAsString(String fileName) {
+        final StringBuilder contentBuilder = new StringBuilder();
+        try (Stream<String> stream = Files.lines(Paths.get("src/test/resources/__files/" + fileName), StandardCharsets.UTF_8)) {
+            stream.forEach(line -> contentBuilder.append(line.trim()));
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return contentBuilder.toString();
+    }
+}

--- a/src/test/resources/__files/getlabelsresponse.json
+++ b/src/test/resources/__files/getlabelsresponse.json
@@ -1,0 +1,24 @@
+{
+  "labels": [
+    {
+      "name": "failsOnRerun",
+      "color": "#807f93"
+    },
+    {
+      "name": "regression",
+      "color": "#807f93"
+    },
+    {
+      "name": "local",
+      "color": "#807f93"
+    },
+    {
+      "name": "smoke",
+      "color": "#807f93"
+    },
+    {
+      "name": "succeedsOnRerun",
+      "color": "#807f93"
+    }
+  ]
+}

--- a/src/test/resources/__files/testcase.xml
+++ b/src/test/resources/__files/testcase.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<testcase classname="My Plan Name" name="My Test Name" time="23" xlink:type="simple" xlink:href="http://myapphref.com"/>

--- a/src/test/resources/__files/testcasewithfailure.xml
+++ b/src/test/resources/__files/testcasewithfailure.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<testcase classname="My Plan Name" name="My Test Name" time="23" xlink:type="simple" xlink:href="http://myapphref.com">
+  <failure message="My Message">My Reason</failure>
+</testcase>

--- a/src/test/resources/__files/testsuite.xml
+++ b/src/test/resources/__files/testsuite.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<testsuites>
+  <testsuite name="Empty Test Suite" tests="0" errors="0" failures="0" skipped="0" time="0" timestamp="2013-05-24T10:23:58">
+    <properties/>
+  </testsuite>
+  <testsuite name="Full Test Suite" tests="3" errors="0" failures="1" skipped="1" time="33" timestamp="2013-05-24T10:23:58">
+    <properties>
+      <property name="environment" value="my env-e"/>
+      <property name="application" value="my app-a"/>
+      <property name="completed-test-cases" value="TESTCASE-1"/>
+      <property name="failed-test-cases" value="TESTCASE-2"/>
+      <property name="skipped-test-cases" value="TESTCASE-3"/>
+    </properties>
+    <testcase classname="My Plan Name 1" name="My Test Name 1" time="11" xlink:type="simple" xlink:href="http://myapphref.com">
+      <properties>
+        <property name="requirement" value="TESTCASE-1"/>
+      </properties>
+    </testcase>
+    <testcase classname="My Plan Name 2" name="My Test Name 2" time="22" xlink:type="simple" xlink:href="http://myapphref.com">
+      <failure message="My Message">My Reason</failure>
+      <properties>
+        <property name="requirement" value="TESTCASE-2"/>
+      </properties>
+    </testcase>
+    <testcase classname="My Plan Name 3" name="My Test Name 3" time="33" xlink:type="simple" xlink:href="http://myapphref.com">
+      <skipped/>
+      <properties>
+        <property name="requirement" value="TESTCASE-3"/>
+      </properties>
+    </testcase>
+  </testsuite>
+</testsuites>


### PR DESCRIPTION
* Added support for skipped tests
* Added support for capturing test case IDs
* Added support for writing out JUnit test report and allow Bamboo to capture the file as a build artifact
* Fixed issue with reporting test duration
* Added support for correctly reporting plan retries
* Updated user-agent string to include JVM and Bamboo version
* Updated test output to include URL to deployment event
* Updated components

TODO
- [x] Create changelog following semantic versioning
- [x] Add unit tests
- [x] Add spotbugs scan
- [x] Add coverage report/check
