### PR TITLE
MABL-5052: expose deployment event ID as a variable to subsequent tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+To be filled out.
+
+## [0.1.10] - July 13, 2021
+
+### Added
+
+* [MABL-5052](https://mabl.atlassian.net/browse/MABL-5052) Share the deployment ID in mabl as a variable MABL_DEPLOYMENT_ID available to subsequent 
+  tasks in the pipeline
+  
+### Changed
+
+* Update spotbugs-maven-plugin, wiremock-jre8-standalone dependencies
+* Suppress spotbugs warning related to injected Bamboo object instances
+
 ## [0.1.9] - June 11, 2021
 
 ### Changed
@@ -80,7 +94,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Respect JVM proxy settings
 
-[Unreleased]: https://github.com/mablhq/bamboo-plugin/compare/bamboo-plugin-0.1.9...head
+[Unreleased]: https://github.com/mablhq/bamboo-plugin/compare/bamboo-plugin-0.1.10...head
+[0.1.10]: https://github.com/mablhq/bamboo-plugin/compare/bamboo-plugin-0.1.9...bamboo-plugin-0.1.10
 [0.1.9]: https://github.com/mablhq/bamboo-plugin/compare/bamboo-plugin-0.1.8...bamboo-plugin-0.1.9
 [0.1.8]: https://github.com/mablhq/bamboo-plugin/compare/bamboo-plugin-0.1.7...bamboo-plugin-0.1.8
 [0.1.7]: https://github.com/mablhq/bamboo-plugin/compare/bamboo-plugin-0.1.6...bamboo-plugin-0.1.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 To be filled out.
 
-## [0.1.10] - July 13, 2021
+## [0.1.10] - July 12, 2021
 
 ### Added
 
-* [MABL-5052](https://mabl.atlassian.net/browse/MABL-5052) Share the deployment ID in mabl as a variable MABL_DEPLOYMENT_ID available to subsequent 
+* [MABL-5052](https://mabl.atlassian.net/browse/MABL-5052) Share the deployment ID in mabl as a variable mabl.deployment.id available to subsequent 
   tasks in the pipeline
   
 ### Changed

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ This plugin facilitates launching of [mabl](https://www.mabl.com) tests as a ste
 6. Enable the task and the plan
 
 Now builds from this plan will trigger Mabl test plan executions of the chosen configuration.
+If executions are scheduled successfully, then the plugin will set the `mabl.deployment.id` variable to correspond
+to the deployment event ID in mabl.
 
 ### Proxy Settings
 

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock-jre8-standalone</artifactId>
-            <version>2.28.1</version>
+            <version>2.29.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -109,7 +109,7 @@
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>4.2.3</version>
+                <version>4.3.0</version>
                 <configuration>
                     <classFilesDirectory>target/classes</classFilesDirectory>
                     <includeFilterFile>spotbugs-filter.xml</includeFilterFile>

--- a/spotbugs-filter.xml
+++ b/spotbugs-filter.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <FindBugsFilter>
-  <Class name="~com\.mabl\.*\.[^.]+"/>
+  <!-- no easy way to avoid this warning with injected objects -->
+  <Match>
+    <Class name="com.mabl.CreateDeployment" />
+    <Method name="CreateDeployment"/>
+    <Bug pattern="EI_EXPOSE_REP2" />
+  </Match>
 </FindBugsFilter>

--- a/src/main/java/com/mabl/CreateDeployment.java
+++ b/src/main/java/com/mabl/CreateDeployment.java
@@ -89,6 +89,8 @@ public class CreateDeployment implements TaskType {
                     createLogLine(
                             "Created deployment at https://app.mabl.com/workspaces/%s/events/%s and triggered '%d' plans.",
                             deployment.workspaceId, deployment.id, deployment.triggeredPlanRunSummaries.size()));
+            // Share the deployment event identifier with subsequent tasks
+            customVariableContext.addCustomData("MABL_DEPLOYMENT_ID", deployment.id);
             do {
                 TimeUnit.MILLISECONDS.sleep(EXECUTION_STATUS_POLLING_INTERNAL_MILLISECONDS);
                 executionResult = apiClient.getExecutionResults(deployment.id);

--- a/src/main/java/com/mabl/CreateDeployment.java
+++ b/src/main/java/com/mabl/CreateDeployment.java
@@ -90,7 +90,7 @@ public class CreateDeployment implements TaskType {
                             "Created deployment at https://app.mabl.com/workspaces/%s/events/%s and triggered '%d' plans.",
                             deployment.workspaceId, deployment.id, deployment.triggeredPlanRunSummaries.size()));
             // Share the deployment event identifier with subsequent tasks
-            customVariableContext.addCustomData("MABL_DEPLOYMENT_ID", deployment.id);
+            customVariableContext.addCustomData("mabl.deployment.id", deployment.id);
             do {
                 TimeUnit.MILLISECONDS.sleep(EXECUTION_STATUS_POLLING_INTERNAL_MILLISECONDS);
                 executionResult = apiClient.getExecutionResults(deployment.id);


### PR DESCRIPTION
The change was tested using the Dump Variable built-in task in Bamboo to show that variable is exposed

Also included:
* Update spotbugs-maven-plugin, wiremock-jre8-standalone dependencies
* Suppress spotbugs warning related to injected Bamboo object instances
