### PR TITLE
[MABL-8395] Allow null duration time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 To be filled out.
 
+## [0.1.12]
+
+### Fixed
+
+* [MABL-8395](https://mabl.atlassian.net/browse/MABL-8395) Fix potential NPE when logging test run status
+
 ## [0.1.11] - May 3, 2022
 
 ### Changed

--- a/src/main/java/com/mabl/CreateDeployment.java
+++ b/src/main/java/com/mabl/CreateDeployment.java
@@ -173,7 +173,10 @@ public class CreateDeployment implements TaskType {
             }
 
             for (ExecutionResult.JourneyExecutionResult journeyResult : summary.journeyExecutions) {
-                final long duration = journeyResult.stopTime - journeyResult.startTime;
+                Long duration = null;
+                if (journeyResult.stopTime != null && journeyResult.startTime != null) {
+                    duration = journeyResult.stopTime - journeyResult.startTime;
+                }
                 final String planName = safePlanName(summary);
                 final String testName = safeJourneyName(summary, journeyResult.id);
                 if (journeyResult.success) {

--- a/src/main/java/com/mabl/MablOutputProvider.java
+++ b/src/main/java/com/mabl/MablOutputProvider.java
@@ -8,6 +8,7 @@ import com.atlassian.bamboo.resultsummary.tests.TestState;
 import com.google.common.collect.Lists;
 import org.jetbrains.annotations.NotNull;
 
+import javax.annotation.Nullable;
 import java.util.Collection;
 
 public class MablOutputProvider implements TestReportProvider {
@@ -31,7 +32,7 @@ public class MablOutputProvider implements TestReportProvider {
         return successfulTestResults.add(testResults);
     }
 
-    public boolean addSuccess(String className, String methodName, long duration) {
+    public boolean addSuccess(String className, String methodName, @Nullable Long duration) {
         return addSuccess(new TestResults(className, methodName, duration));
     }
 
@@ -40,7 +41,7 @@ public class MablOutputProvider implements TestReportProvider {
         return failedTestResults.add(testResults);
     }
 
-    public boolean addFailure(String className, String methodName, long duration) {
+    public boolean addFailure(String className, String methodName, @Nullable Long duration) {
         return addFailure(new TestResults(className, methodName, duration));
     }
 


### PR DESCRIPTION
[MABL-8395](https://mabl.atlassian.net/browse/MABL-8395)

There is a potential NPE for the following line since `stopTime` and `startTime` are `Long`, but need to be unboxed to perform the subtraction. To address this, I added a check to ensure that both are not `null` before performing the subtraction, and keeping the duration as `null` otherwise. Based on the types, the duration of a `TestResults` is marked as `@Nullable` so I am just passing the `null` along.
```final long duration = journeyResult.stopTime - journeyResult.startTime;```