### PR TITLE
[MABL-8542] Fix multiple test runs triggered by DataTables being listed as a single test run

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -2,7 +2,7 @@ name: Build and Test
 on: push
 jobs:
   build-base:
-    timeout-minutes: 10
+    timeout-minutes: 15
     runs-on: ubuntu-20.04 # LTS EoL Apr 2025
     # Skip if contains [skip ci]
     if: "!contains(github.event.head_commit.message, 'skip ci')"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@main
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: '8'
@@ -20,7 +20,7 @@ jobs:
           architecture: x64
 
       # Use caching to speed reload
-      - uses: actions/cache@v1
+      - uses: actions/cache@v3
         with:
           path: ~/.m2
           key: ${{ runner.OS }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ To be filled out.
 ### Fixed
 
 * [MABL-8395](https://mabl.atlassian.net/browse/MABL-8395) Fix potential NPE when logging test run status
+* [MABL-8542](https://mabl.atlassian.net/browse/MABL-8542) Fix multiple test runs triggered by DataTables being listed as a single test run
 
 ## [0.1.11] - May 3, 2022
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ See the [Atlassian Docs](https://marketplace.atlassian.com/apps/1219102/mabl-dep
 
 ### Building from source and running locally
 
-NOTE: You need to run on Java 8 with a version less than 255. Otherwise, you will run into  [this issue](https://confluence.atlassian.com/bamkb/bamboo-fails-to-configure-embedded-database-in-environments-with-java-update-version-higher-than-255-1018269728.html).
+NOTE: You need to run on Java 8 with a version less than 255 (i.e. `1.8.0_345` will not work). Otherwise, you will run into  [this issue](https://confluence.atlassian.com/bamkb/bamboo-fails-to-configure-embedded-database-in-environments-with-java-update-version-higher-than-255-1018269728.html).
 
 Install the [Atlassian SDK](https://developer.atlassian.com/server/framework/atlassian-sdk/set-up-the-atlassian-plugin-sdk-and-build-a-project/)
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ See the [Atlassian Docs](https://marketplace.atlassian.com/apps/1219102/mabl-dep
 
 ### Building from source and running locally
 
+NOTE: You need to run on Java 8 with a version less than 255. Otherwise, you will run into  [this issue](https://confluence.atlassian.com/bamkb/bamboo-fails-to-configure-embedded-database-in-environments-with-java-update-version-higher-than-255-1018269728.html).
+
 Install the [Atlassian SDK](https://developer.atlassian.com/server/framework/atlassian-sdk/set-up-the-atlassian-plugin-sdk-and-build-a-project/)
 
 1. Clone this repo && cd into it
@@ -65,6 +67,13 @@ Run these commands
 ```bash
 docker volume create --name bambooVolume
 docker run -v bambooVolume:/var/atlassian/application-data/bamboo --name="bamboo" --init -d -p 54663:54663 -p 8085:8085 atlassian/bamboo-server
+docker start bamboo
+```
+
+If you are running on an M1 Mac, then you'll need an additional `--platform linux/amd64` flag on the `docker run` command.
+```bash
+docker volume create --name bambooVolume
+docker run --platform linux/amd64 -v bambooVolume:/var/atlassian/application-data/bamboo --name="bamboo" --init -d -p 54663:54663 -p 8085:8085 atlassian/bamboo-server
 docker start bamboo
 ```
 

--- a/src/main/java/com/mabl/domain/ExecutionResult.java
+++ b/src/main/java/com/mabl/domain/ExecutionResult.java
@@ -34,7 +34,7 @@ public class ExecutionResult implements ApiResult {
         public final PlanSummary plan;
         public final PlanExecutionResult planExecution;
         public final List<JourneySummary> journeys;
-        public final List<JourneyExecutionResult> journeyExecutions;
+        public final List<TestRunResult> testRunResults;
 
         @JsonCreator
         public ExecutionSummary(
@@ -46,7 +46,7 @@ public class ExecutionResult implements ApiResult {
                 @JsonProperty("plan") final PlanSummary plan,
                 @JsonProperty("plan_execution") final PlanExecutionResult planExecution,
                 @JsonProperty("journeys") final List<JourneySummary> journeys,
-                @JsonProperty("journey_executions") final List<JourneyExecutionResult> journeysExecutions
+                @JsonProperty("journey_executions") final List<TestRunResult> testRunResults
         ) {
             this.status = status;
             this.statusCause = statusCause;
@@ -56,7 +56,7 @@ public class ExecutionResult implements ApiResult {
             this.plan = plan;
             this.planExecution = planExecution;
             this.journeys = journeys;
-            this.journeyExecutions = journeysExecutions;
+            this.testRunResults = testRunResults;
         }
     }
 
@@ -107,7 +107,7 @@ public class ExecutionResult implements ApiResult {
     }
 
     @SuppressWarnings("WeakerAccess")
-    public static class JourneyExecutionResult {
+    public static class TestRunResult {
         public final String id;
         public final String executionId;
         public final String href;
@@ -118,9 +118,10 @@ public class ExecutionResult implements ApiResult {
         public final Long startTime;
         public final Long stopTime;
         public final List<TestCaseId> testCases;
+        public final String scenarioName;
 
         @JsonCreator
-        public JourneyExecutionResult(
+        public TestRunResult(
                 @JsonProperty("journey_id") final String id,
                 @JsonProperty("executionId") final String executionId,
                 @JsonProperty("href") final String href,
@@ -130,7 +131,8 @@ public class ExecutionResult implements ApiResult {
                 @JsonProperty("success") final boolean success,
                 @JsonProperty("start_time") final Long startTime,
                 @JsonProperty("stop_time") final Long stopTime,
-                @JsonProperty("test_cases") final List<TestCaseId> testCases
+                @JsonProperty("test_cases") final List<TestCaseId> testCases,
+                @JsonProperty("scenario_name") final String scenarioName
         ) {
             this.id = id;
             this.executionId = executionId;
@@ -142,6 +144,7 @@ public class ExecutionResult implements ApiResult {
             this.startTime = startTime;
             this.stopTime = stopTime;
             this.testCases = testCases;
+            this.scenarioName = scenarioName;
         }
     }
 

--- a/src/main/java/com/mabl/test/output/TestSuiteSerializer.java
+++ b/src/main/java/com/mabl/test/output/TestSuiteSerializer.java
@@ -29,24 +29,24 @@ public class TestSuiteSerializer {
 
         final Map<String, SortedSet<String>> testCaseIDs = new HashMap<>();
 
-        for (ExecutionResult.JourneyExecutionResult journeyResult : summary.journeyExecutions) {
-            final String testName = safeJourneyName(summary, journeyResult.id);
+        for (ExecutionResult.TestRunResult testRunResult : summary.testRunResults) {
+            final String testName = safeJourneyName(summary, testRunResult.id);
             TestCase testCase = new TestCase(
                     planName,
                     testName,
-                    getDuration(journeyResult),
-                    journeyResult.appHref
+                    getDuration(testRunResult),
+                    testRunResult.appHref
             );
 
-            if (journeyResult.testCases != null && !journeyResult.testCases.isEmpty()) {
-                switch (journeyResult.status) {
+            if (testRunResult.testCases != null && !testRunResult.testCases.isEmpty()) {
+                switch (testRunResult.status) {
                     case "failed":
                     case "completed":
                     case "skipped":
                         final SortedSet<String> ids =
-                                testCaseIDs.computeIfAbsent(journeyResult.status + "-test-cases", k -> new TreeSet<>());
+                                testCaseIDs.computeIfAbsent(testRunResult.status + "-test-cases", k -> new TreeSet<>());
                         final SortedSet<String> newIds = new TreeSet<>();
-                        for (ExecutionResult.TestCaseId id : journeyResult.testCases) {
+                        for (ExecutionResult.TestCaseId id : testRunResult.testCases) {
                             newIds.add(id.caseId);
                         }
                         ids.addAll(newIds);
@@ -62,11 +62,11 @@ public class TestSuiteSerializer {
 
             testSuite.addToTestCases(testCase).incrementTests();
 
-            if (!journeyResult.success && null != journeyResult.status) {
-                switch (journeyResult.status) {
+            if (!testRunResult.success && null != testRunResult.status) {
+                switch (testRunResult.status) {
                     case "failed":
                     case "terminated":
-                        final Failure failure = new Failure(journeyResult.status, journeyResult.statusCause);
+                        final Failure failure = new Failure(testRunResult.status, testRunResult.statusCause);
                         testCase.setFailure(failure);
                         testSuite.incrementFailures();
                         break;
@@ -76,7 +76,7 @@ public class TestSuiteSerializer {
                         break;
                     default:
                         LOG.warn(String.format("unexpected status '%s' found for test '%s' in plan '%s'%n",
-                                journeyResult.status,
+                                testRunResult.status,
                                 planName,
                                 testName));
                 }
@@ -98,7 +98,7 @@ public class TestSuiteSerializer {
                 TimeUnit.SECONDS.convert( (summary.stopTime - summary.startTime), TimeUnit.MILLISECONDS) : 0;
     }
 
-    private static long getDuration(ExecutionResult.JourneyExecutionResult summary) {
+    private static long getDuration(ExecutionResult.TestRunResult summary) {
         return summary.stopTime != null ?
                 TimeUnit.SECONDS.convert( (summary.stopTime - summary.startTime), TimeUnit.MILLISECONDS) : 0;
     }


### PR DESCRIPTION
[MABL-8542](https://mabl.atlassian.net/browse/MABL-8542)

Currently, if Bamboo triggers a deployment where multiple tests have the same name (due to DataTable scenarios), then the tests will only be listed as a single test run per status (success/failure). This issue is caused by a Bamboo bug that has been logged [here](https://jira.atlassian.com/browse/BAM-20487). The status of this bug is that it is on the longterm backlog, which means that Bamboo is unlikely to implement this anytime soon. The bug basically means that tests with the same test name + same status will only show up as a single test result in Bamboo. Since the same test is run multiple times with a DataTable, the same test name and plan name is applied and as a result, you’ll see this issue.

To remedy this, I added the scenario name as part of the test name to create a more unique test name. NOTE: mabl currently allows multiple scenarios in the DataTable to have the same name (or no name), so this is not guaranteed to be unique for all test runs.

![image](https://user-images.githubusercontent.com/46035684/201725554-0bdfa1fd-72d0-4324-b391-58205e8e92ec.png)

![image](https://user-images.githubusercontent.com/46035684/201725521-ca3ec893-65ef-4700-948e-4918db2a56ff.png)

Note 2: I also renamed `JourneyExecutionResult` to `TestRunResult` to match the API definition.