### PR TITLE
[MABL-8568] Prepare for next development iteration and update release instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,17 +92,18 @@ To login as an admin during testing, you can use the username "admin" and passwo
 
 ### Manual Deployment
 
-1. Merge code into default branch and push
-2. Run `atlas-mvn clean install` 
-3. Upload the resulting `target/bamboo-plugin-$VERSION.jar` to the [Atlassian marketplace](https://marketplace.atlassian.com/manage/apps/1219102/versions)
+1. 
+2. Merge code into default branch and push
+2. Create a new branch and update the pom.xml plugin version to `{next-version}-SNAPSHOT`, and merge the branch.
+    - This step would normally be performed by the `atlas-mvn release:prepare` or part of the `atlas-release` command, but this has to be done manually since this is manually deploying instead of relying on `atlas-mvn release:prepare` or `atlas-release`.
+3. Run `atlas-mvn clean install` 
+4. Upload the resulting `target/bamboo-plugin-$VERSION.jar` to the [Atlassian marketplace](https://marketplace.atlassian.com/manage/apps/1219102/versions)
 Make sure your version doesn't include `-SNAPSHOT` if you're uploading manually.
 Uploading will require an admin to the mablhq Atlassian vendor account.
    1. To manually upload a new version to the [Atlassian marketplace](https://marketplace.atlassian.com/manage/apps/1219102/versions),
         Click on `Create version` button and upload the jar file. You will also need to set a unique build number for the release.
    2. Most of the default options will be pre-filled, but change them if they are no longer applicable.
    3. For the `compatible to` field, choose the latest version of Bamboo.
-4. Create a new branch and update the pom.xml plugin version to `{next-version}-SNAPSHOT`, and merge the branch.
-   - This step would normally be performed by the `atlas-mvn release:prepare` or part of the `atlas-release` command, but this has to be done manually since this is manually deploying instead of relying on `atlas-mvn release:prepare` or `atlas-release`.
 
 ### Deployment (does not work with the current pom.xml file)
 

--- a/README.md
+++ b/README.md
@@ -92,18 +92,21 @@ To login as an admin during testing, you can use the username "admin" and passwo
 
 ### Manual Deployment
 
-1. 
-2. Merge code into default branch and push
-2. Create a new branch and update the pom.xml plugin version to `{next-version}-SNAPSHOT`, and merge the branch.
-    - This step would normally be performed by the `atlas-mvn release:prepare` or part of the `atlas-release` command, but this has to be done manually since this is manually deploying instead of relying on `atlas-mvn release:prepare` or `atlas-release`.
-3. Run `atlas-mvn clean install` 
-4. Upload the resulting `target/bamboo-plugin-$VERSION.jar` to the [Atlassian marketplace](https://marketplace.atlassian.com/manage/apps/1219102/versions)
-Make sure your version doesn't include `-SNAPSHOT` if you're uploading manually.
-Uploading will require an admin to the mablhq Atlassian vendor account.
-   1. To manually upload a new version to the [Atlassian marketplace](https://marketplace.atlassian.com/manage/apps/1219102/versions),
-        Click on `Create version` button and upload the jar file. You will also need to set a unique build number for the release.
-   2. Most of the default options will be pre-filled, but change them if they are no longer applicable.
-   3. For the `compatible to` field, choose the latest version of Bamboo.
+1. Create a new branch for releasing the plugin.
+2. Remove `-SNAPSHOT` from the plugin version and update the `<scm>` `<tag>` version to `bamboo-plugin-{currentVersion}` in the pom.xml file. `currentVersion` should be in the form `0.1.12`.
+3. Commit and push changes (preferably with a commit message like `[maven-release-plugin] prepare release bamboo-plugin-{currentVersion}`).
+4. Run `atlas-mvn clean install`.
+5. Upload the resulting `target/bamboo-plugin-$VERSION.jar` to the [Atlassian marketplace](https://marketplace.atlassian.com/manage/apps/1219102/versions).
+   Make sure your version doesn't include `-SNAPSHOT` if you're uploading manually since that is the development build.
+   Uploading will require an admin to the mablhq Atlassian vendor account.
+    1. To manually upload a new version to the [Atlassian marketplace](https://marketplace.atlassian.com/manage/apps/1219102/versions),
+       Click on `Create version` button and upload the jar file. You will also need to set a unique build number for the release.
+    2. Most of the default options will be pre-filled, but change them if they are no longer applicable.
+    3. For the `compatible to` field, choose the latest version of Bamboo.
+6. Tag the current commit with `git tag -a bamboo-plugin-{currentVersion}` and push the tag by running `git push origin bamboo-plugin-{currentVersion}`.
+7. Update the plugin version to `{nextVersion}-SNAPSHOT`, where `nextVersion` should be in the form `0.1.13`.
+   Commit and push changes (preferably with a commit message like `[maven-release-plugin] prepare for next development iteration`).
+8. Open branch for PR approval and merge.
 
 ### Deployment (does not work with the current pom.xml file)
 

--- a/README.md
+++ b/README.md
@@ -101,10 +101,11 @@ Uploading will require an admin to the mablhq Atlassian vendor account.
         Click on `Create version` button and upload the jar file. You will also need to set a unique build number for the release.
    2. Most of the default options will be pre-filled, but change them if they are no longer applicable.
    3. For the `compatible to` field, choose the latest version of Bamboo.
+4. Create a new branch and update the pom.xml plugin version to `{next-version}-SNAPSHOT`, and merge the branch.
+   - This step would normally be performed by the `atlas-mvn release:prepare` or part of the `atlas-release` command, but this has to be done manually since this is manually deploying instead of relying on `atlas-mvn release:prepare` or `atlas-release`.
 
 ### Deployment (does not work with the current pom.xml file)
 
 1. Merge code into default branch and push
 2. Run `atlas-mvn clean install`
-3. Run `atlas-mvn release:prepare` This will update pom.xml with new version and tag the release with current version minus `-SNAPSHOT`
-4. Run `atlas-mvn release:perform`
+3. Run `atlas-release` This will update pom.xml with new version and tag the release with current version minus `-SNAPSHOT`, before putting that back together with the latest version.

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.mabl.bamboo</groupId>
     <artifactId>bamboo-plugin</artifactId>
-    <version>0.1.12</version>
+    <version>0.1.13-SNAPSHOT</version>
 
     <organization>
         <name>mabl</name>
@@ -16,7 +16,7 @@
         <url>https://github.com/mablhq/bamboo-plugin.git</url>
         <connection>scm:git:git@github.com:mablhq/bamboo-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:mablhq/bamboo-plugin.git</developerConnection>
-        <tag>bamboo-plugin-0.1.12</tag>
+        <tag>bamboo-plugin-0.1.8</tag>
     </scm>
 
     <name>mabl deployment</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.mabl.bamboo</groupId>
     <artifactId>bamboo-plugin</artifactId>
-    <version>0.1.12-SNAPSHOT</version>
+    <version>0.1.12</version>
 
     <organization>
         <name>mabl</name>
@@ -16,7 +16,7 @@
         <url>https://github.com/mablhq/bamboo-plugin.git</url>
         <connection>scm:git:git@github.com:mablhq/bamboo-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:mablhq/bamboo-plugin.git</developerConnection>
-        <tag>bamboo-plugin-0.1.8</tag>
+        <tag>bamboo-plugin-0.1.12</tag>
     </scm>
 
     <name>mabl deployment</name>


### PR DESCRIPTION
This is a result of running `atlas-release` but failing at the end due to not having set up the repository info in the pom.xml. I updated the release instructions on how to manually perform the same set of actions instead.