### PR TITLE
[MABL-8395] Guard against NPE if `startTime` is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 To be filled out.
 
+## [0.1.13]
+
+### Fixed
+
+* [MABL-8395](https://mabl.atlassian.net/browse/MABL-8395) Fix logging error if there are skipped test runs
+
 ## [0.1.12]
 
 ### Fixed
 
-* [MABL-8395](https://mabl.atlassian.net/browse/MABL-8395) Fix potential NPE when logging test run status
 * [MABL-8542](https://mabl.atlassian.net/browse/MABL-8542) Fix multiple test runs triggered by DataTables being listed as a single test run
 
 ## [0.1.11] - May 3, 2022

--- a/README.md
+++ b/README.md
@@ -95,18 +95,19 @@ To login as an admin during testing, you can use the username "admin" and passwo
 1. Create a new branch for releasing the plugin.
 2. Remove `-SNAPSHOT` from the plugin version and update the `<scm>` `<tag>` version to `bamboo-plugin-{currentVersion}` in the pom.xml file. `currentVersion` should be in the form `0.1.12`.
 3. Commit and push changes (preferably with a commit message like `[maven-release-plugin] prepare release bamboo-plugin-{currentVersion}`).
-4. Run `atlas-mvn clean install`.
-5. Upload the resulting `target/bamboo-plugin-$VERSION.jar` to the [Atlassian marketplace](https://marketplace.atlassian.com/manage/apps/1219102/versions).
+4. Open branch for PR review and wait for approvals. Once ready to merge, perform the following steps.
+5. Run `atlas-mvn clean install`.
+6. Upload the resulting `target/bamboo-plugin-$VERSION.jar` to the [Atlassian marketplace](https://marketplace.atlassian.com/manage/apps/1219102/versions).
    Make sure your version doesn't include `-SNAPSHOT` if you're uploading manually since that is the development build.
    Uploading will require an admin to the mablhq Atlassian vendor account.
     1. To manually upload a new version to the [Atlassian marketplace](https://marketplace.atlassian.com/manage/apps/1219102/versions),
        Click on `Create version` button and upload the jar file. You will also need to set a unique build number for the release.
     2. Most of the default options will be pre-filled, but change them if they are no longer applicable.
     3. For the `compatible to` field, choose the latest version of Bamboo.
-6. Tag the current commit with `git tag -a bamboo-plugin-{currentVersion}` and push the tag by running `git push origin bamboo-plugin-{currentVersion}`.
-7. Update the plugin version to `{nextVersion}-SNAPSHOT`, where `nextVersion` should be in the form `0.1.13`.
+7. Tag the current commit with `git tag -a bamboo-plugin-{currentVersion}` and push the tag by running `git push origin bamboo-plugin-{currentVersion}`.
+8. Update the plugin version to `{nextVersion}-SNAPSHOT`, where `nextVersion` should be in the form `0.1.13`.
    Commit and push changes (preferably with a commit message like `[maven-release-plugin] prepare for next development iteration`).
-8. Open branch for PR approval and merge.
+9. Merge the branch. Alternatively, merge the branch after step 4, and open a new branch for step 8.
 
 ### Deployment (does not work with the current pom.xml file)
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ To login as an admin during testing, you can use the username "admin" and passwo
        Click on `Create version` button and upload the jar file. You will also need to set a unique build number for the release.
     2. Most of the default options will be pre-filled, but change them if they are no longer applicable.
     3. For the `compatible to` field, choose the latest version of Bamboo.
-7. Tag the current commit with `git tag -a bamboo-plugin-{currentVersion}` and push the tag by running `git push origin bamboo-plugin-{currentVersion}`.
+7. Tag the current commit with `git tag -a -m "[maven-release-plugin] bamboo-plugin-{currentVersion}" bamboo-plugin-{currentVersion}` and push the tag by running `git push origin bamboo-plugin-{currentVersion}`.
 8. Update the plugin version to `{nextVersion}-SNAPSHOT`, where `nextVersion` should be in the form `0.1.13`.
    Commit and push changes (preferably with a commit message like `[maven-release-plugin] prepare for next development iteration`).
 9. Merge the branch. Alternatively, merge the branch after step 4, and open a new branch for step 8.

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.mabl.bamboo</groupId>
     <artifactId>bamboo-plugin</artifactId>
-    <version>0.1.13-SNAPSHOT</version>
+    <version>0.1.13</version>
 
     <organization>
         <name>mabl</name>
@@ -16,7 +16,7 @@
         <url>https://github.com/mablhq/bamboo-plugin.git</url>
         <connection>scm:git:git@github.com:mablhq/bamboo-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:mablhq/bamboo-plugin.git</developerConnection>
-        <tag>bamboo-plugin-0.1.8</tag>
+        <tag>bamboo-plugin-0.1.13</tag>
     </scm>
 
     <name>mabl deployment</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.mabl.bamboo</groupId>
     <artifactId>bamboo-plugin</artifactId>
-    <version>0.1.13</version>
+    <version>0.1.14-SNAPSHOT</version>
 
     <organization>
         <name>mabl</name>

--- a/src/main/java/com/mabl/test/output/TestSuiteSerializer.java
+++ b/src/main/java/com/mabl/test/output/TestSuiteSerializer.java
@@ -94,12 +94,12 @@ public class TestSuiteSerializer {
     }
 
     private static long getDuration(ExecutionResult.ExecutionSummary summary) {
-        return summary.stopTime != null ?
+        return (summary.stopTime != null && summary.startTime != null) ?
                 TimeUnit.SECONDS.convert( (summary.stopTime - summary.startTime), TimeUnit.MILLISECONDS) : 0;
     }
 
     private static long getDuration(ExecutionResult.TestRunResult summary) {
-        return summary.stopTime != null ?
+        return (summary.stopTime != null && summary.startTime != null) ?
                 TimeUnit.SECONDS.convert( (summary.stopTime - summary.startTime), TimeUnit.MILLISECONDS) : 0;
     }
 


### PR DESCRIPTION
[MABL-8395](https://mabl.atlassian.net/browse/MABL-8395)

This is a continuation of https://github.com/mablhq/bamboo-plugin/pull/29 since there is another spot where we can throw a `NullPointerException` if either the `startTime` or `stopTime` is not set on the test run. The `startTime` will not be set if the test run is skipped.