### PR TITLE
Address class loading issue on bamboo.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 To be filled out.
 
+## [0.1.14]
+
+[MABL-9127](https://mabl.atlassian.net/browse/MABL-9127) Fix class loading errors on recent versions of Bamboo.
+
 ## [0.1.13]
 
 ### Fixed

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <properties>
         <bamboo.version>6.3.2</bamboo.version>
         <bamboo.data.version>6.3.2</bamboo.data.version>
-        <amps.version>6.3.15</amps.version>
+        <amps.version>6.3.21</amps.version> <!-- looking for new versions of this? try here: https://packages.atlassian.com/maven-external/com/atlassian/maven/plugins/maven-bamboo-plugin/ -->
         <plugin.testrunner.version>1.2.3</plugin.testrunner.version>
         <atlassian.spring.scanner.version>1.2.13</atlassian.spring.scanner.version>
         <!-- This key is used to keep the consistency between the key in atlassian-plugin.xml and the key to generate bundle. -->
@@ -90,7 +90,21 @@
             <artifactId>gson</artifactId>
             <version>2.2.2-atlassian-1</version>
         </dependency>
-
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.14.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>2.14.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.14.2</version>
+        </dependency>
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock-jre8-standalone</artifactId>
@@ -149,7 +163,7 @@
 
             <plugin>
                 <groupId>com.atlassian.maven.plugins</groupId>
-                <artifactId>maven-bamboo-plugin</artifactId>
+                <artifactId>maven-bamboo-plugin</artifactId> <!-- note: this id changes (maven-bamboo-plugin -> bamboo-maven-plugin) in future versions. -->
                 <version>${amps.version}</version>
                 <extensions>true</extensions>
                 <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <properties>
         <bamboo.version>6.3.2</bamboo.version>
         <bamboo.data.version>6.3.2</bamboo.data.version>
-        <amps.version>6.3.21</amps.version> <!-- looking for new versions of this? try here: https://packages.atlassian.com/maven-external/com/atlassian/maven/plugins/maven-bamboo-plugin/ -->
+        <amps.version>8.9.0</amps.version>
         <plugin.testrunner.version>1.2.3</plugin.testrunner.version>
         <atlassian.spring.scanner.version>1.2.13</atlassian.spring.scanner.version>
         <!-- This key is used to keep the consistency between the key in atlassian-plugin.xml and the key to generate bundle. -->
@@ -115,6 +115,7 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <version>4.5.13</version>
+            <scope>provided</scope> <!-- this is a "banned" reference, meaning it is provided by Bamboo at runtime. See: https://community.developer.atlassian.com/t/more-info-on-amps-banned-plugin-dependency/46036 -->
         </dependency>
     </dependencies>
 
@@ -163,7 +164,7 @@
 
             <plugin>
                 <groupId>com.atlassian.maven.plugins</groupId>
-                <artifactId>maven-bamboo-plugin</artifactId> <!-- note: this id changes (maven-bamboo-plugin -> bamboo-maven-plugin) in future versions. -->
+                <artifactId>bamboo-maven-plugin</artifactId>
                 <version>${amps.version}</version>
                 <extensions>true</extensions>
                 <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.mabl.bamboo</groupId>
     <artifactId>bamboo-plugin</artifactId>
-    <version>0.1.14-SNAPSHOT</version>
+    <version>0.1.14</version>
 
     <organization>
         <name>mabl</name>
@@ -16,7 +16,7 @@
         <url>https://github.com/mablhq/bamboo-plugin.git</url>
         <connection>scm:git:git@github.com:mablhq/bamboo-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:mablhq/bamboo-plugin.git</developerConnection>
-        <tag>bamboo-plugin-0.1.13</tag>
+        <tag>bamboo-plugin-0.1.14</tag>
     </scm>
 
     <name>mabl deployment</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.mabl.bamboo</groupId>
     <artifactId>bamboo-plugin</artifactId>
-    <version>0.1.14</version>
+    <version>0.1.15-SNAPSHOT</version>
 
     <organization>
         <name>mabl</name>

--- a/src/main/java/com/mabl/MablConstants.java
+++ b/src/main/java/com/mabl/MablConstants.java
@@ -82,7 +82,7 @@ class MablConstants {
     private static String getBambooVersion() {
         return Optional.ofNullable(System.getProperty("atlassian.sdk.version")).
                 orElseGet(() -> {
-                    final String pluginVersion = System.getenv("AMPS_PLUGIN_VERSION");
+                    final String pluginVersion = System.getenv("AMPS_PLUGIN_VERSION"); // it appears this env variable is no longer set.
                     return StringUtils.isEmpty(pluginVersion) ? "unknown" : pluginVersion;
                 });
     }


### PR DESCRIPTION
We are seeing class loading errors when trying to use the plugin in recent versions of Bamboo.

This PR bumps the maven-bamboo-plugin and adds dependencies for jackson JARs used for serialization.

I also dug into an issue where the useragent no longer includes the bamboo version, but in local testing it appears the environment variable for that is no longer present.