### PR TITLE
[MABL-9882] Address NullPointerException caused by checking count on null object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 To be filled out.
 
+## [0.1.15]
+
+[MABL-9882](https://mabl.atlassian.net/browse/MABL-9882) Fix NullPointerException when triggered plan run data is not present.
+
 ## [0.1.14]
 
 [MABL-9127](https://mabl.atlassian.net/browse/MABL-9127) Fix class loading errors on recent versions of Bamboo.

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.mabl.bamboo</groupId>
     <artifactId>bamboo-plugin</artifactId>
-    <version>0.1.15-SNAPSHOT</version>
+    <version>0.1.15</version>
 
     <organization>
         <name>mabl</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.mabl.bamboo</groupId>
     <artifactId>bamboo-plugin</artifactId>
-    <version>0.1.15</version>
+    <version>0.1.16-SNAPSHOT</version>
 
     <organization>
         <name>mabl</name>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <url>https://github.com/mablhq/bamboo-plugin.git</url>
         <connection>scm:git:git@github.com:mablhq/bamboo-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:mablhq/bamboo-plugin.git</developerConnection>
-        <tag>bamboo-plugin-0.1.14</tag>
+        <tag>bamboo-plugin-0.1.15</tag>
     </scm>
 
     <name>mabl deployment</name>

--- a/src/main/java/com/mabl/CreateDeployment.java
+++ b/src/main/java/com/mabl/CreateDeployment.java
@@ -83,6 +83,7 @@ public class CreateDeployment implements TaskType {
         ExecutionResult executionResult;
         final ProxyConfiguration proxyConfig = new ProxyConfiguration(proxyAddress, proxyUsername, proxyPassword);
         try (RestApiClient apiClient = new RestApiClient(MABL_REST_API_BASE_URL, formApiKey, proxyConfig)) {
+
             CreateDeploymentResult deployment = apiClient.createDeploymentEvent(
                     environmentId, applicationId, planLabels, mablBranch, properties);
             buildLogger.addBuildLogEntry(

--- a/src/main/java/com/mabl/CreateDeployment.java
+++ b/src/main/java/com/mabl/CreateDeployment.java
@@ -83,13 +83,12 @@ public class CreateDeployment implements TaskType {
         ExecutionResult executionResult;
         final ProxyConfiguration proxyConfig = new ProxyConfiguration(proxyAddress, proxyUsername, proxyPassword);
         try (RestApiClient apiClient = new RestApiClient(MABL_REST_API_BASE_URL, formApiKey, proxyConfig)) {
-
             CreateDeploymentResult deployment = apiClient.createDeploymentEvent(
                     environmentId, applicationId, planLabels, mablBranch, properties);
             buildLogger.addBuildLogEntry(
                     createLogLine(
-                            "Created deployment at https://app.mabl.com/workspaces/%s/events/%s and triggered '%d' plans.",
-                            deployment.workspaceId, deployment.id, deployment.triggeredPlanRunSummaries.size()));
+                            "Created deployment at https://app.mabl.com/workspaces/%s/events/%s",
+                            deployment.workspaceId, deployment.id));
             // Share the deployment event identifier with subsequent tasks
             customVariableContext.addCustomData("mabl.deployment.id", deployment.id);
             do {


### PR DESCRIPTION
Fix NPE on a logging call that logged the count of plans triggered.

When the plan trigger list was null, this caused an NPE and the build to fail in bamboo with an unhelpful error message.

We are still researching why the API is not returning triggered plan run information.

TODO:

- [x] bump version on deploy